### PR TITLE
Fix configure-proxy.js to read .env files using dotenv

### DIFF
--- a/frontend/configure-proxy.js
+++ b/frontend/configure-proxy.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+require('dotenv').config();
+
 const fs = require('fs');
 const path = require('path');
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "axios": "^1.6.0",
+        "dotenv": "^17.2.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1"
@@ -6695,12 +6696,15 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dotenv-expand": {
@@ -13876,6 +13880,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-scripts/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/read-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "axios": "^1.6.0",
+    "dotenv": "^17.2.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1"


### PR DESCRIPTION
## Summary
- Add dotenv dependency to frontend package.json to enable reading .env files
- Update configure-proxy.js to require and configure dotenv 
- Enables the script to read REACT_APP_BACKEND_PORT from .env files instead of only shell environment variables

## Test plan
- [ ] Create a `.env` file in frontend directory with `REACT_APP_BACKEND_PORT=4001`
- [ ] Run the configure-proxy script and verify it reads the port from the .env file
- [ ] Verify the proxy configuration is updated correctly in package.json

Fixes [ATXP-246](https://linear.app/novellum/issue/ATXP-246/allow-for-configurable-atxp-express-example-ports)

🤖 Generated with [Claude Code](https://claude.ai/code)