### PR TITLE
Fix .env file path loading for production mode

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -13,7 +13,10 @@ import { ConsoleLogger, LogLevel } from '@atxp/common';
 import { getATXPConnectionString, findATXPAccount, validateATXPConnectionString } from './atxp-utils';
 
 // Load environment variables
-dotenv.config({ path: path.join(__dirname, '.env') });
+const envPath = process.env.NODE_ENV === 'production' 
+  ? path.join(__dirname, '../.env')
+  : path.join(__dirname, '.env');
+dotenv.config({ path: envPath });
 
 // Create the Express app
 const app = express();

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -13,6 +13,7 @@ import { ConsoleLogger, LogLevel } from '@atxp/common';
 import { getATXPConnectionString, findATXPAccount, validateATXPConnectionString } from './atxp-utils';
 
 // Load environment variables
+// In production, __dirname points to dist/, but .env is in the parent directory
 const envPath = process.env.NODE_ENV === 'production' 
   ? path.join(__dirname, '../.env')
   : path.join(__dirname, '.env');


### PR DESCRIPTION
## Summary
- Fix .env file path when NODE_ENV=production (dist/../.env instead of dist/.env)
- Ensures backend can read environment variables correctly in production mode
- Maintains backward compatibility with development mode

## Problem
When running in production mode, the compiled backend runs from the `dist/` folder, so `__dirname` points to `backend/dist/`. The previous code tried to load `.env` from `backend/dist/.env`, but the actual file is at `backend/.env`.

## Solution
Added conditional path resolution based on NODE_ENV:
- Production: `path.join(__dirname, '../.env')` 
- Development: `path.join(__dirname, '.env')`

## Test plan
- [ ] Test that .env variables are loaded correctly in development mode
- [ ] Test that .env variables are loaded correctly in production mode
- [ ] Verify both `npm run dev` and `npm run start` work with environment configuration

🤖 Generated with [Claude Code](https://claude.ai/code)