### PR TITLE
Set NODE_ENV=production in backend start script for proper .env loading

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "Express backend for agent-demo",
   "main": "dist/server.js",
   "scripts": {
-    "start": "node dist/server.js",
+    "start": "NODE_ENV=production node dist/server.js",
     "dev": "nodemon --exec ts-node server.ts",
     "build": "tsc",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- Set `NODE_ENV=production` in the backend's start script to ensure proper .env file path resolution
- Fixes issue where `npm run server:prod` wasn't reading environment variables from backend/.env

## Problem
When running `npm run server:prod` from the project root, the backend wasn't setting `NODE_ENV=production`, causing it to look for the .env file in the wrong location:
- Without NODE_ENV=production: looked for `.env` in `backend/dist/.env` (doesn't exist)
- With NODE_ENV=production: correctly looks for `.env` in `backend/.env`

## Solution
Modified `backend/package.json` to set `NODE_ENV=production` in the start script:
```json
"start": "NODE_ENV=production node dist/server.js"
```

## Test Results
- ✅ `npm run server:prod` now correctly reads PORT=3999 from backend/.env
- ✅ Server starts on the configured port instead of defaulting to 3001
- ✅ All environment variables are properly loaded in production mode

## Test plan
- [ ] Test `npm run server:prod` loads environment variables correctly
- [ ] Test `npm run dev` still works in development mode  
- [ ] Verify both modes use the correct .env file paths

🤖 Generated with [Claude Code](https://claude.ai/code)